### PR TITLE
Cleanup and partial reimplementation in terms of Hash::Agnostic

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,9 @@
     "Elizabeth Mattijsen"
   ],
   "build-depends" : [ ],
-  "depends" : [ ],
+  "depends" : [
+    "Hash::Agnostic:ver<0.0.8>:auth<cpan:ELIZABETH>"
+  ],
   "description" : "role for ordered Hashes",
   "license" : "Artistic-2.0",
   "name" : "Hash::Ordered",

--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
 NAME
 ====
 
-Hash::Ordered - blah blah blah
+Hash::Ordered - role for ordered Hashes
 
 SYNOPSIS
 ========
 
     use Hash::Ordered;
 
+    my %m is Hash::Ordered = a => 42, b => 666;
+
 DESCRIPTION
 ===========
 
-Hash::Ordered is ...
+Exports a `Hash::Ordered` role that can be used to indicate the implementation of a `Hash` in which the keys are ordered the way the `Hash` got initialized or any later keys got added.
+
+Since `Hash::Ordered` is a role, you can also use it as a base for creating your own custom implementations of hashes.
 
 AUTHOR
 ======
 
 Elizabeth Mattijsen <liz@wenzperl.nl>
 
+Source can be located at: https://github.com/lizmat/Hash-Ordered . Comments and Pull Requests are welcome.
+
 COPYRIGHT AND LICENSE
 =====================
 
-Copyright 2018 Elizabeth Mattijsen
+Copyright 2018,2021 Elizabeth Mattijsen
 
 This library is free software; you can redistribute it and/or modify it under the Artistic License 2.0.
 

--- a/lib/Hash/Ordered.pm6
+++ b/lib/Hash/Ordered.pm6
@@ -82,9 +82,6 @@ my \result :=
         self.pairs.join(" ")
     }
 
-    method perl(::?ROLE:D:) is DEPRECATED("raku") {
-        self.raku
-    }
     method raku(::?ROLE:D:) {
         self.perlseen(self.^name, {
           ~ self.^name

--- a/lib/Hash/Ordered.pm6
+++ b/lib/Hash/Ordered.pm6
@@ -1,6 +1,10 @@
 use v6.c;
 
-role Hash::Ordered:ver<0.0.1>:auth<cpan:ELIZABETH> {
+use Hash::Agnostic:ver<0.0.8>:auth<cpan:ELIZABETH>;
+
+role Hash::Ordered:ver<0.0.1>:auth<cpan:ELIZABETH>
+  does Hash::Agnostic
+{
     has str @.keys;
 
     method !add-key(\key --> Nil) {

--- a/lib/Hash/Ordered.pm6
+++ b/lib/Hash/Ordered.pm6
@@ -15,40 +15,6 @@ role Hash::Ordered:ver<0.0.1>:auth<cpan:ELIZABETH>
         @!keys.splice: @!keys.first(*.WHICH eq $WHICH,:k), 1;
     }
 
-    method STORE(*@values) {
-        self!STORE(@values);
-        self
-    }
-
-    method !STORE(@values --> Nil) {
-        my $last := Mu;
-        my int $found;
-
-        for @values {
-            if $_ ~~ Pair {
-                self.AT-KEY(.key) = .value;
-                ++$found;
-            }
-            elsif $_ ~~ Failure {
-                .throw
-            }
-            elsif !$last =:= Mu {
-                self.AT-KEY($last) = $_;
-                ++$found;
-                $last := Mu;
-            }
-            elsif $_ ~~ Map {
-                $found += self!STORE([.pairs])
-            }
-            else {
-                $last := $_;
-            }
-        }
-
-        X::Hash::Store::OddNumber.new(:$found, :$last).throw
-          unless $last =:= Mu;
-    }
-
     method AT-KEY(::?ROLE:D: \key) is raw {
         self!add-key(key) unless self.EXISTS-KEY(key);
 my \result :=

--- a/lib/Hash/Ordered.pm6
+++ b/lib/Hash/Ordered.pm6
@@ -21,9 +21,6 @@ my \result :=
         nextcallee()(self, key)
 ; dd result; result
     }
-    method ASSIGN-KEY(::?ROLE:D: \key, \value) is raw {
-        self.AT-KEY(key) = value
-    }
     method BIND-KEY(::?ROLE:D: \key, \value) is raw {
         self!add-key(key) unless self.EXISTS-KEY(key);
         nextsame;
@@ -31,13 +28,6 @@ my \result :=
     method DELETE-KEY(::?ROLE:D: \key) {
         self!del-key(key) if self.EXISTS-KEY(key);
         nextsame;
-    }
-
-    method values(::ROLE:D:) {
-        @!keys.map: { self.AT-KEY($_) }
-    }
-    method pairs(::ROLE:D:) {
-        @!keys.map: { Pair.new: $_, self.AT-KEY($_) }
     }
 
     method gist(::?ROLE:D:) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -60,7 +60,8 @@ subtest {
       'can we check existence of removed slice';
     is %h.elems, @keys - 4, 'did we update number of elements';
 }, 'can we delete a slice';
-=finish
+
+lives-ok { %h = @pairs }, 'can re-initialize a Hash';
 
 subtest {
     plan 3;
@@ -68,7 +69,5 @@ subtest {
     is-deeply (%h{}:v),      @values, 'does a value zen-slice work';
     is-deeply (%h{*}:v),     @values, 'does a value whatever-slice work';
 }, 'can we do value slices';
-
-lives-ok { %h = @pairs }, 'can re-initialize a Hash';
 
 # vim: expandtab shiftwidth=4

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -53,9 +53,6 @@ subtest {
 
 subtest {
     plan 4;
-dd %h<d>:exists;
-dd %h<e>:exists;
-dd %h<f>:exists;
     is-deeply %h<d e f>:exists, (True,True,True),
       'can we check existence of an existing slice';
     is %h<d e f>:delete, (628,271,6), 'can we remove an existing slice';


### PR DESCRIPTION
Rebased on `Hash::Agnostic`, which allowed cleanup of a good chunk of redundant code, then reimplemented core UPPERCASE methods and got the existing tests fully passing again.

This is now ready for more difficult tests.  :-)
